### PR TITLE
Add additional metadata fields and fix issue with trailing slashes

### DIFF
--- a/kosh/api/graphql.py
+++ b/kosh/api/graphql.py
@@ -47,7 +47,7 @@ class graphql(_api):
         """
         view = ql.as_view(self.path, schema=self.__schema(), graphiql=True)
         logger().debug("Deploying GraphQL endpoint %s", self.path)
-        flask.add_url_rule(self.path, self.path, view)
+        flask.add_url_rule(self.path, self.path, view, strict_slashes=False)
 
     def __schema(self) -> Schema:
         """

--- a/kosh/api/restful.py
+++ b/kosh/api/restful.py
@@ -40,9 +40,15 @@ class restful(_api):
         path = lambda endpoint: "{}/{}".format(self.path, endpoint)
         logger().debug("Deploying RESTful endpoint %s", self.path)
 
-        flask.add_url_rule(path("entries"), path("entries"), self.entries)
-        flask.add_url_rule(path("ids"), path("ids"), self.ids)
-        flask.add_url_rule(path("spec"), path("spec"), self.spec)
+        flask.add_url_rule(
+            path("entries"), path("entries"), self.entries, strict_slashes=False
+        )
+        flask.add_url_rule(
+            path("ids"), path("ids"), self.ids, strict_slashes=False
+        )
+        flask.add_url_rule(
+            path("spec"), path("spec"), self.spec, strict_slashes=False
+        )
 
         flask.register_blueprint(
             get_swaggerui_blueprint(

--- a/kosh/elastic/index.py
+++ b/kosh/elastic/index.py
@@ -137,6 +137,22 @@ class index:
                         "schema",
                         load(open("{}/{}".format(root, spec[uid]["schema"]))),
                     ),
+                    (
+                        "authors",
+                        loads(spec[uid]["authors"])
+                    ),
+                    (
+                        "title",
+                        loads(spec[uid]["title"])
+                    ),
+                    (
+                        "source_languages",
+                        loads(spec[uid]["source_languages"])
+                    ),
+                    (
+                        "target_languages",
+                        loads(spec[uid]["target_languages"])
+                    ),
                 ]
                 for uid in spec.sections()
             ]

--- a/kosh/kosh.py
+++ b/kosh/kosh.py
@@ -143,12 +143,14 @@ class kosh:
                 "about": {**instance.config["info"]},
                 "dicts": {i.uid: specs(i) for i in instance.lexicons.values()},
             },
+            strict_slashes=False,
         )
 
         flask.add_url_rule(
             "{}/<uid>".format(config.root),
             "{}/<uid>".format(config.root),
             lambda uid: specs(instance.lexicons[uid]),
+            strict_slashes=False,
         )
 
         for lexicon in instance.lexicons.values():

--- a/kosh/kosh.py
+++ b/kosh/kosh.py
@@ -117,6 +117,10 @@ class kosh:
         def specs(lexicon):
             return {
                 "size": lexicon.size,
+                "title": lexicon.title,
+                "authors": lexicon.authors,
+                "source_languages": lexicon.source_languages,
+                "target_languages": lexicon.target_languages,
                 "properties": [
                     "id",
                     *[i for i in lexicon.schema.mappings.properties],


### PR DESCRIPTION
Hey Phil,
könntest du, wenn du Zeit hast, hier einen Blick drauf werfen?

Es geht um zwei Änderungen:
1. Ich habe die Metadaten um Autoren, Titel und Sprachen ergänzt und sie jetzt auch hier eingebunden... Auf den ersten Blick scheint es so zu funktionieren, wie ich es mir vorgestellt habe. Muss ich die Info noch an anderer Stelle einfügen? Die zusätzlichen Felder in [kosh_data](https://github.com/cceh/kosh_data/commit/3e3589ed46b994bc8948cc8b3893d3ddf107a8be) sind ebenfalls noch im `add-metadata` Branch und nicht gemerged.
2. URLs, die mit einem trailing slash enden, haben bisher zu einem 404 geführt. Der zusätzliche Parameter umgeht das. Siehe <https://kosh.uni-koeln.de/api/de_alcedo/> vs <https://kosh.uni-koeln.de/api/de_alcedo>  
(Fix von hier: <https://stackoverflow.com/questions/33241050/trailing-slash-triggers-404-in-flask-path-rule>)

Danke!