### PR TITLE
Add --help parameter

### DIFF
--- a/kosh/param/help.py
+++ b/kosh/param/help.py
@@ -1,0 +1,57 @@
+from importlib import import_module
+from sys import argv, exit
+from os import path
+from typing import List
+from pkgutil import iter_modules
+
+from ..utility.concretemethod import concretemethod
+from ..utility.logger import logger
+from ._param import _param
+
+
+class help(_param):
+    """
+    Show help and list commands
+    """
+
+    @staticmethod
+    def get_param_values(name, argv) -> List[str]:
+        values = []
+        found = False
+        for arg in argv:
+            if arg == f"--{name}":
+                found = True
+                continue
+            elif arg.startswith("--") and found:
+                break
+            if found:
+                values.append(arg)
+        return values
+
+    @concretemethod
+    def _parse(self, params: List[str]) -> None:
+        """
+        todo: docs
+        """
+        modules = [
+            i
+            for _, i, _ in iter_modules([path.dirname(__file__)])
+            if i[0] != ("_")
+        ]
+        logger().debug("Found param modules %s", modules)
+
+        print("Parameters:")
+        maxlen = max(map(len, modules))
+        for module in modules:
+            param_cls = import_module("kosh.param.{}".format(module)).__dict__[
+                module
+            ]
+            values = self.get_param_values(module, argv)
+            userval = (
+                ", set to '{}'".format(", ".join(values)) if values else ""
+            )
+            print(
+                f"    --{module:<{maxlen}}  {param_cls.__doc__.strip()}{userval}"
+            )
+
+        exit(0)


### PR DESCRIPTION
Add a simple `--help` parameter that lists other available parameters, their arguments if set by the user and the python docstring of the parameter. Then it exits the program.

This looks like the following:
```bash
kosh --config_file kosh.ini --data_host elasticsearch --log_level DEBUG --help
2023-07-04 14:33:25 [INFO] <kosh.kosh> Started kosh with pid 10811
2023-07-04 14:33:25 [INFO] <kosh.kosh> Loaded API endpoint modules ['fcs', 'graphql', 'restful']
Parameters:
    --api_port     todo: docs
    --api_root     todo: docs
    --config_file  todo: docs, set to 'kosh.ini'
    --config_text  todo: docs
    --data_host    todo: docs, set to 'elasticsearch'
    --data_pool    todo: docs
    --data_root    todo: docs
    --data_sync    todo: docs
    --help         Show help and list commands
    --log_file     todo: docs
    --log_level    todo: docs, set to 'DEBUG'
2023-07-04 14:33:25 [CRITICAL] <kosh.kosh> 0
2023-07-04 14:33:25 [INFO] <kosh.kosh> Stopped kosh with pid 10811
```