### PR TITLE
Escape Elasticsearch index names, where applicable

### DIFF
--- a/kosh.ini
+++ b/kosh.ini
@@ -28,7 +28,8 @@
 ; host: 127.0.0.1
 
 ## [data.pool]
-## String prefix to pool all Elasticsearch indices together.
+## String prefix to pool all Elasticsearch indices together. Should respect the
+## character limitations regarding Elasticsearch index naming.
 ; pool: kosh
 
 ## [data.root]

--- a/kosh/elastic/index.py
+++ b/kosh/elastic/index.py
@@ -4,6 +4,7 @@ from glob import glob
 from itertools import groupby
 from json import load, loads
 from os import path
+from re import sub
 from time import time
 from typing import Any, Callable, Dict, List
 
@@ -111,7 +112,13 @@ class index:
         """
         pool = instance.config["data"]["pool"]
         root = path.dirname(file)
-        spec = ConfigParser(converters={"value": cls.__value})
+        spec = ConfigParser(
+            converters={
+                "index": cls.__index,
+                "value": cls.__value,
+            }
+        )
+
         spec.read_file(open(file))
 
         return [
@@ -124,7 +131,10 @@ class index:
                     ),
                     (
                         "pool",
-                        "{}[{}]".format(spec[uid].getvalue("pool", pool), uid),
+                        "{}[{}]".format(
+                            spec[uid].getindex("pool", pool),
+                            cls.__index(uid),
+                        ),
                     ),
                     (
                         "files",
@@ -177,6 +187,15 @@ class index:
         }
 
         return lexicon.schema
+
+    @classmethod
+    def __index(cls, value: str) -> str:
+        """
+        todo: docs
+        """
+        return sub(
+            "^[+.\-_]+", "", sub('[\s,:?"*/\\\#<>|]+', "_", value.lower())
+        )
 
     @classmethod
     def __value(cls, value: str) -> Any:


### PR DESCRIPTION
This pull request implements a [custom ConfigParser converter](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour) for the `.kosh` file parser which escapes strings to [qualify as Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html#indices-create-api-path-params).