### PR TITLE
Refine parameter help

### DIFF
--- a/kosh/api/graphql.py
+++ b/kosh/api/graphql.py
@@ -25,7 +25,7 @@ from ._api import _api
 
 class graphql(_api):
     """
-    todo: docs
+    A GraphQL endpoint serving lexical data
     """
 
     graphenemap = dotdictionary(

--- a/kosh/api/graphql.py
+++ b/kosh/api/graphql.py
@@ -87,7 +87,7 @@ class graphql(_api):
         typing = {}
 
         for property in self.mapping:
-            array_like = "[{}]".format(property) in fields
+            array_like = f"[{property}]" in fields
             graphene = self.graphenemap[self.mapping[property].type]
             typing[property] = List(graphene) if array_like else graphene()
 

--- a/kosh/api/restful.py
+++ b/kosh/api/restful.py
@@ -17,7 +17,7 @@ from ._api import _api
 
 class restful(_api):
     """
-    todo: docs
+    A RESTful endpoint serving lexical data
     """
 
     swaggermap = dotdictionary(

--- a/kosh/api/restful.py
+++ b/kosh/api/restful.py
@@ -37,7 +37,7 @@ class restful(_api):
         """
         todo: docs
         """
-        path = lambda endpoint: "{}/{}".format(self.path, endpoint)
+        path = lambda endpoint: f"{self.path}/{endpoint}"
         logger().debug("Deploying RESTful endpoint %s", self.path)
 
         flask.add_url_rule(path("entries"), path("entries"), self.entries)
@@ -96,7 +96,7 @@ class restful(_api):
 
             return (
                 swagger
-                if not "[{}]".format(name) in fields
+                if not f"[{name}]" in fields
                 else {"type": "array", "items": swagger}
             )
 
@@ -126,7 +126,7 @@ class restful(_api):
             return {
                 "200": {
                     "description": "Matching dictionary entries",
-                    "schema": {"$ref": "#/definitions/{}".format(name)},
+                    "schema": {"$ref": f"#/definitions/{name}"},
                 },
                 "400": {"description": "Missing or invalid parameter"},
             }
@@ -216,7 +216,7 @@ class restful(_api):
             if isinstance(body, datetime):
                 return body.isoformat()
 
-            raise TypeError("Type {} not serializable".format(type(body)))
+            raise TypeError(f"Type {type(body)} not serializable")
 
         return Response(
             dumps(body, default=serialize, ensure_ascii=False),

--- a/kosh/elastic/index.py
+++ b/kosh/elastic/index.py
@@ -68,7 +68,7 @@ class index:
         indices = []
         logger().debug("Looking for dict definitions in %s", root)
 
-        for file in glob("{}/**/{}".format(root, spec), recursive=True):
+        for file in glob(f"{root}/**/{spec}", recursive=True):
             try:
                 indices += cls.__parser(file)
             except Exception:
@@ -88,7 +88,7 @@ class index:
         unique = lambda value: (value[2], int(time() / 60))
 
         for tick, _ in groupby(task.event_gen(yield_nones=0), key=unique):
-            file = "{}/{}".format(tick[0], spec)
+            file = f"{tick[0]}/{spec}"
 
             if ".git" not in file and path.isfile(file):
                 logger().debug("Observed change in %s", tick[0])
@@ -139,19 +139,13 @@ class index:
                     (
                         "files",
                         [
-                            "{}/{}".format(root, file)
+                            f"{root}/{file}"
                             for file in spec[uid].getvalue("files")
                         ],
                     ),
                     (
                         "schema",
-                        load(
-                            open(
-                                "{}/{}".format(
-                                    root, spec[uid].getvalue("schema")
-                                )
-                            )
-                        ),
+                        load(open(f"{root}/{spec[uid].getvalue('schema')}")),
                     ),
                     *[
                         (key, spec[uid].getvalue(key))

--- a/kosh/kosh.py
+++ b/kosh/kosh.py
@@ -58,21 +58,21 @@ class kosh:
             instance.config.read_dict(defaultconfig)
             logger().info("Started kosh with pid %s", getpid())
 
-            root = "{}/{}".format(path.dirname(__file__), "api")
+            root = f"{path.dirname(__file__)}/api"
             modules = [i for _, i, _ in iter_modules([root]) if i[0] != ("_")]
             logger().info("Loaded API endpoint modules %s", modules)
 
             instance.modules = [
-                import_module("kosh.api.{}".format(module)).__dict__[module]
+                import_module(f"kosh.api.{module}").__dict__[module]
                 for module in modules
             ]
 
             for arg in [i for i in argv if i.startswith("--")]:
                 try:
-                    module = "kosh.param.{}".format(arg[2:])
+                    module = f"kosh.param.{arg[2:]}"
                     import_module(module).__dict__[arg[2:]](argv)
                 except Exception:
-                    exit("Invalid parameter or argument to {}".format(arg[2:]))
+                    exit(f"Invalid parameter or argument to {arg[2:]}")
 
             config = dotdictionary(instance.config["data"])
             connections.create_connection(hosts=[config.host])
@@ -147,8 +147,8 @@ class kosh:
         )
 
         flask.add_url_rule(
-            "{}/<uid>".format(config.root),
-            "{}/<uid>".format(config.root),
+            f"{config.root}/<uid>",
+            f"{config.root}/<uid>",
             lambda uid: specs(instance.lexicons[uid]),
         )
 

--- a/kosh/param/_param.py
+++ b/kosh/param/_param.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Any, List
 
 from ..utility.logger import logger
 
@@ -27,6 +27,13 @@ class _param(ABC):
 
     @abstractmethod
     def _parse(self, params: List[str]) -> None:
+        """
+        todo: docs
+        """
+        raise NotImplementedError("Too abstract")
+
+    @abstractmethod
+    def _value(self) -> Any:
         """
         todo: docs
         """

--- a/kosh/param/api_port.py
+++ b/kosh/param/api_port.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -8,7 +8,7 @@ from ._param import _param
 
 class api_port(_param):
     """
-    todo: docs
+    The port kosh will listen on
     """
 
     @concretemethod
@@ -21,3 +21,10 @@ class api_port(_param):
 
         instance.config.set("api", "port", params[0])
         logger().info("Set api port to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("api", "port")

--- a/kosh/param/api_root.py
+++ b/kosh/param/api_root.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -8,7 +8,7 @@ from ._param import _param
 
 class api_root(_param):
     """
-    todo: docs
+    The API context path kosh will serve
     """
 
     @concretemethod
@@ -21,3 +21,10 @@ class api_root(_param):
 
         instance.config.set("api", "root", params[0])
         logger().info("Set api root to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("api", "root")

--- a/kosh/param/config_file.py
+++ b/kosh/param/config_file.py
@@ -1,5 +1,5 @@
 from sys import exit
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -9,7 +9,7 @@ from ._param import _param
 
 class config_file(_param):
     """
-    todo: docs
+    The configuration file kosh will use
     """
 
     @concretemethod
@@ -22,4 +22,12 @@ class config_file(_param):
         except Exception:
             exit("Invalid config file {}".format(params[0]))
 
+        instance.config.set("DEFAULT", "conf", params[0])
         logger().info("Read config file %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("DEFAULT", "conf")

--- a/kosh/param/config_file.py
+++ b/kosh/param/config_file.py
@@ -20,7 +20,7 @@ class config_file(_param):
         try:
             instance.config.read_file(open(params[0]))
         except Exception:
-            exit("Invalid config file {}".format(params[0]))
+            exit(f"Invalid config file {params[0]}")
 
         instance.config.set("DEFAULT", "conf", params[0])
         logger().info("Read config file %s", params[0])

--- a/kosh/param/config_text.py
+++ b/kosh/param/config_text.py
@@ -20,7 +20,7 @@ class config_text(_param):
         try:
             instance.config.read_string(params[0])
         except Exception:
-            exit("Invalid config string {}".format(params[0]))
+            exit(f"Invalid config string {params[0]}")
 
         logger().info("Read config string %s", params[0])
 

--- a/kosh/param/config_text.py
+++ b/kosh/param/config_text.py
@@ -1,5 +1,5 @@
 from sys import exit
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -9,7 +9,7 @@ from ._param import _param
 
 class config_text(_param):
     """
-    todo: docs
+    Arbitrary configuration values kosh will use
     """
 
     @concretemethod
@@ -23,3 +23,10 @@ class config_text(_param):
             exit("Invalid config string {}".format(params[0]))
 
         logger().info("Read config string %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return None

--- a/kosh/param/data_host.py
+++ b/kosh/param/data_host.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -8,7 +8,7 @@ from ._param import _param
 
 class data_host(_param):
     """
-    todo: docs
+    The Elasticsearch host kosh will use
     """
 
     @concretemethod
@@ -18,3 +18,10 @@ class data_host(_param):
         """
         instance.config.set("data", "host", params[0])
         logger().info("Set data host to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("data", "host")

--- a/kosh/param/data_pool.py
+++ b/kosh/param/data_pool.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -8,7 +8,7 @@ from ._param import _param
 
 class data_pool(_param):
     """
-    todo: docs
+    String prefix to pool all Elasticsearch indices together
     """
 
     @concretemethod
@@ -18,3 +18,10 @@ class data_pool(_param):
         """
         instance.config.set("data", "pool", params[0])
         logger().info("Set data pool to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("data", "pool")

--- a/kosh/param/data_root.py
+++ b/kosh/param/data_root.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -8,7 +8,7 @@ from ._param import _param
 
 class data_root(_param):
     """
-    todo: docs
+    The path to XML lexical data with kosh files
     """
 
     @concretemethod
@@ -18,3 +18,10 @@ class data_root(_param):
         """
         instance.config.set("data", "root", params[0])
         logger().info("Set data root to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("data", "root")

--- a/kosh/param/data_sync.py
+++ b/kosh/param/data_sync.py
@@ -1,5 +1,5 @@
 from distutils.util import strtobool
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -9,7 +9,7 @@ from ._param import _param
 
 class data_sync(_param):
     """
-    todo: docs
+    The interval in which files are checked for changes
     """
 
     @concretemethod
@@ -19,3 +19,10 @@ class data_sync(_param):
         """
         instance.config.set("data", "sync", str(strtobool(params[0])))
         logger().info("Set data sync to %r", bool(strtobool(params[0])))
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("data", "sync")

--- a/kosh/param/help.py
+++ b/kosh/param/help.py
@@ -4,6 +4,7 @@ from pkgutil import iter_modules
 from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
+from ..utility.instance import instance
 from ..utility.logger import logger
 from ._param import _param
 
@@ -19,23 +20,32 @@ class help(_param):
         todo: docs
         """
         summary = metadata.metadata("kosh").get("summary")
-        print(summary + "\n" + len(summary) * "-" + "\n")
+        print(summary + "\n" + len(summary) * "-")
 
         root = path.dirname(__file__)
         modules = [i for _, i, _ in iter_modules([root]) if i[0] != ("_")]
         logger().debug("Found param modules %s", modules)
 
-        maxlen = max(map(len, modules))
-        print("Parameters:")
+        param_maxlen = max(map(len, modules))
+        print("\nParameters:")
 
         for module in modules:
             param = import_module(f"kosh.param.{module}").__dict__[module]
             value = param._value(param)
 
             print(
-                f"    --{module:<{maxlen}} ",
+                f"    --{module:<{param_maxlen}} ",
                 param.__doc__.strip().split("\n")[0],
                 f"(set to: {value})" if value else "",
+            )
+
+        module_maxlen = max(map(len, [i.__name__ for i in instance.modules]))
+        print("\nLoaded API endpoint modules:")
+
+        for module in instance.modules:
+            print(
+                f"    {module.__name__:<{module_maxlen}} -",
+                module.__doc__.strip().split("\n")[0],
             )
 
         _exit(0)

--- a/kosh/param/help.py
+++ b/kosh/param/help.py
@@ -1,0 +1,57 @@
+from importlib import import_module
+from sys import argv, exit
+from os import path
+from typing import List
+from pkgutil import iter_modules
+
+from ..utility.concretemethod import concretemethod
+from ..utility.logger import logger
+from ._param import _param
+
+
+class help(_param):
+    """
+    Show help and list commands
+    """
+
+    @staticmethod
+    def get_param_values(name, argv) -> List[str]:
+        values = []
+        found = False
+        for arg in argv:
+            if arg == f"--{name}":
+                found = True
+                continue
+            elif arg.startswith("--") and found:
+                break
+            if found:
+                values.append(arg)
+        return values
+
+    @concretemethod
+    def _parse(self, params: List[str]) -> None:
+        """
+        todo: docs
+        """
+        modules = [
+            i
+            for _, i, _ in iter_modules([path.dirname(__file__)])
+            if i[0] != ("_")
+        ]
+        logger().debug("Found param modules %s", modules)
+
+        print("Parameters:")
+        maxlen = max(map(len, modules))
+        for module in modules:
+            param_cls = import_module("kosh.param.{}".format(module)).__dict__[
+                module
+            ]
+            values = self.get_param_values(module, argv)
+            userval = (
+                ", set to '{}'".format(", ".join(values)) if values else ""
+            )
+            print(
+                f"    --{module:<{maxlen}}  {param_cls.__doc__.strip()}{userval}"
+            )
+
+        exit(0)

--- a/kosh/param/log_file.py
+++ b/kosh/param/log_file.py
@@ -1,6 +1,6 @@
 from logging import FileHandler, getLogger
 from sys import exit
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -10,7 +10,7 @@ from ._param import _param
 
 class log_file(_param):
     """
-    todo: docs
+    Specifies the the file kosh will log to
     """
 
     @concretemethod
@@ -30,3 +30,10 @@ class log_file(_param):
 
         instance.config.set("logger", "file", params[0])
         logger().info("Set log file to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("logger", "file")

--- a/kosh/param/log_file.py
+++ b/kosh/param/log_file.py
@@ -26,7 +26,7 @@ class log_file(_param):
             handler.setFormatter(getLogger().handlers[0].formatter)
             getLogger().addHandler(handler)
         except Exception:
-            exit("Invalid log file {}".format(params[0]))
+            exit(f"Invalid log file {params[0]}")
 
         instance.config.set("logger", "file", params[0])
         logger().info("Set log file to %s", params[0])

--- a/kosh/param/log_level.py
+++ b/kosh/param/log_level.py
@@ -1,6 +1,6 @@
 from logging import getLevelName
 from sys import exit
-from typing import List
+from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
 from ..utility.instance import instance
@@ -10,7 +10,7 @@ from ._param import _param
 
 class log_level(_param):
     """
-    todo: docs
+    Specifies the kosh logger level
     """
 
     @concretemethod
@@ -25,3 +25,10 @@ class log_level(_param):
 
         instance.config.set("logger", "level", params[0])
         logger().info("Set log level to %s", params[0])
+
+    @concretemethod
+    def _value(self) -> Any:
+        """
+        todo: docs
+        """
+        return instance.config.get("logger", "level")

--- a/kosh/param/log_level.py
+++ b/kosh/param/log_level.py
@@ -21,7 +21,7 @@ class log_level(_param):
         try:
             logger().setLevel(getLevelName(params[0]))
         except Exception:
-            exit("Invalid log level {}".format(params[0]))
+            exit(f"Invalid log level {params[0]}")
 
         instance.config.set("logger", "level", params[0])
         logger().info("Set log level to %s", params[0])

--- a/kosh/utility/defaultconfig.py
+++ b/kosh/utility/defaultconfig.py
@@ -4,6 +4,7 @@ passed to ``ConfigParser.read_dict`` to define sane default values.
 """
 defaultconfig = {
     "DEFAULT": {
+        "conf": "",
         "name": "kosh",
     },
     "api": {


### PR DESCRIPTION
This pull request is inspired by, contains and supersedes https://github.com/cceh/kosh/pull/123.

Inspired by the pull request opened by @Querela, this pull request contains minimal docstrings for all `kosh.param`s which will be displayed when calling the `kosh` python entrypoint with the `--help` parameter. It further refines the implementation provided by the pull request https://github.com/cceh/kosh/pull/123 to include not only values of parameters specified on the CLI together with the `--help` parameter, but all available (as in default) parameter values. Last but not least, the commit https://github.com/cceh/kosh/commit/f34086656e72f24f984d322c7e8551995f7fe49a drops the `"".format()` string formatting function in favour of [literal string interpolation](https://peps.python.org/pep-0498) (`f""`).