### PR TITLE
Fix `--data_sync` parameter type checking

### DIFF
--- a/kosh/param/data_sync.py
+++ b/kosh/param/data_sync.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from typing import Any, List
 
 from ..utility.concretemethod import concretemethod
@@ -17,8 +16,11 @@ class data_sync(_param):
         """
         todo: docs
         """
-        instance.config.set("data", "sync", str(strtobool(params[0])))
-        logger().info("Set data sync to %r", bool(strtobool(params[0])))
+        if not params[0].isdigit():
+            raise TypeError()
+
+        instance.config.set("data", "sync", params[0])
+        logger().info("Set data sync to %s", params[0])
 
     @concretemethod
     def _value(self) -> Any:


### PR DESCRIPTION
This pull request fixes a bug within the `--data_sync` parameter argument handling as reported in #128. The parameter value should be a string containing only digits (as asserted by the [`param.isdigit()`](https://github.com/cceh/kosh/blob/fix/data_sync/kosh/param/data_sync.py#L19) call introduced through this pull request) but was evaluated as boolean.