### PR TITLE
Enforce consistent dictionary naming

### DIFF
--- a/kosh/elastic/entry.py
+++ b/kosh/elastic/entry.py
@@ -28,7 +28,7 @@ class entry:
         todo: docs
         """
         filename = path.basename(file)
-        namespaces = {**instance.config["namespaces"]}
+        namespaces = {**instance.config._sections["namespaces"]}
         xpaths = self.lexicon.schema.mappings._meta._xpaths
 
         logger().debug("Parsing file %s/%s", self.lexicon.uid, filename)
@@ -59,7 +59,7 @@ class entry:
         todo: docs
         """
         element = etree.tostring(root, encoding="unicode")
-        namespaces = {**instance.config["namespaces"]}
+        namespaces = {**instance.config._sections["namespaces"]}
         xpaths = self.lexicon.schema.mappings._meta._xpaths
 
         for name in root.xpath(xpaths.id, namespaces=namespaces) or [None]:

--- a/kosh/elastic/index.py
+++ b/kosh/elastic/index.py
@@ -4,7 +4,6 @@ from glob import glob
 from itertools import groupby
 from json import load, loads
 from os import path
-from re import sub
 from time import time
 from typing import Any, Callable, Dict, List
 
@@ -112,13 +111,7 @@ class index:
         """
         pool = instance.config["data"]["pool"]
         root = path.dirname(file)
-        spec = ConfigParser(
-            converters={
-                "index": cls.__index,
-                "value": cls.__value,
-            }
-        )
-
+        spec = ConfigParser(converters={"value": cls.__value})
         spec.read_file(open(file))
 
         return [
@@ -131,10 +124,7 @@ class index:
                     ),
                     (
                         "pool",
-                        "{}[{}]".format(
-                            spec[uid].getindex("pool", pool),
-                            cls.__index(uid),
-                        ),
+                        f"{spec[uid].getvalue('pool', pool)}[{uid}]",
                     ),
                     (
                         "files",
@@ -181,15 +171,6 @@ class index:
         }
 
         return lexicon.schema
-
-    @classmethod
-    def __index(cls, value: str) -> str:
-        """
-        todo: docs
-        """
-        return sub(
-            "^[+.\-_]+", "", sub('[\s,:?"*/\\\#<>|]+', "_", value.lower())
-        )
 
     @classmethod
     def __value(cls, value: str) -> Any:

--- a/kosh/elastic/index.py
+++ b/kosh/elastic/index.py
@@ -4,6 +4,7 @@ from glob import glob
 from itertools import groupby
 from json import load, loads
 from os import path
+from re import compile
 from time import time
 from typing import Any, Callable, Dict, List
 
@@ -112,6 +113,8 @@ class index:
         pool = instance.config["data"]["pool"]
         root = path.dirname(file)
         spec = ConfigParser(converters={"value": cls.__value})
+
+        spec.SECTCRE = compile(r"^\[(?P<header>[a-z][_a-z0-9]+)\]$")
         spec.read_file(open(file))
 
         return [


### PR DESCRIPTION
This pull request enforces a consistent dictionary naming convention to ensures a fail-fast approach regarding the [ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html#indices-create-api-path-params) as well as [`graphql-python`](https://github.com/graphql-python/graphql-core-legacy/blob/v2.3.2/graphql/utils/assert_valid_name.py#L3) naming requirements by setting the [`ConfigParser.SECTCRE`](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.SECTCRE) to: `^\[([a-z][_a-z0-9]+)\]$`. By testing and failing early upon incorrect dictionary names, kosh should be more resilient in regards to malformatted dictionary definitions.