### PR TITLE
Relax Python Version Requirement and Run as UID/GID 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.17
+FROM python:3.11-alpine3.18
 ADD . /tmp/kosh
 RUN pip install /tmp/kosh && find /root /tmp -mindepth 1 -delete
 USER 1000:1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.11-alpine3.17
+FROM python:3.8-alpine3.17
 ADD . /tmp/kosh
 RUN pip install /tmp/kosh && find /root /tmp -mindepth 1 -delete
-USER nobody
+USER 1000:1000
 ENTRYPOINT ["kosh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kosh"
 description = "kosh - APIs for Lexical Data"
 
 version = "0.0.2"
-requires-python = ">= 3.11"
+requires-python = ">= 3.8"
 
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This pull request fixes #125 as it relaxes the required Python version to 3.8, as suggested by @Querela. Furthermore it switches the runtime user (within Docker) from `nobody` to UID:GID `1000:1000`. This should reduce edge-cases where running as `nobody` leads to increased privilages through NFS configurations. Further, the first userland UID:GID under most *nix distributions default to `1000:1000` which seems to be a sensible default here, too.