### PR TITLE
Avoid retrieving duplicate documents by ID

### DIFF
--- a/kosh/elastic/search.py
+++ b/kosh/elastic/search.py
@@ -26,7 +26,7 @@ class search:
         try:
             return [
                 {**item.to_dict(), "id": item.meta.id}
-                for item in find.mget(ids)
+                for item in find.mget(list(set(ids)))
                 if item
             ]
         except Exception:


### PR DESCRIPTION
`/dicts/foo/restful/ids?ids=bar&ids=bar&ids=bar&ids=bar` returns the same document four times. I am aware this doesn't mean the end of the world, but maybe something close.

This just ensures the `ids` list that came from the controller and is passed to `elasticsearch-dsl`'s `doc.mget` method contains only unique IDs by doing a quick `list(set(ids))`.

Technically, `set(ids)` would be enough, as [elasticsearch-dsl just loops over the elements of any sequence](https://github.com/elastic/elasticsearch-dsl-py/blob/c063cfaaa22aeb06fa49ef0701aaae007920e3f5/elasticsearch_dsl/_sync/document.py#L204), but the `docs` argument of `mget` is documented as a _"list of `id`s of the documents to be retrieved or a list of document specifications"_ (although the type hint for `docs` is `List[Dict[str, Any]]`, so I guess they're just being sloppy with their docs and/or type hints anyway).